### PR TITLE
INFRA-260 Pull image before deploying

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,7 +75,10 @@ jobs:
             export STATIC_SITE_PORT=$STATIC_SITE_PORT     && \
             docker-compose -p $PROJECT_ID                    \
                            -f docker-compose.prod.yml        \
-                           up --force-recreate --build -d
+                           pull static_site               && \
+            docker-compose -p $PROJECT_ID                    \
+                           -f docker-compose.prod.yml        \
+                           up --force-recreate -d
 
       - name: Wait
         run: sleep 15


### PR DESCRIPTION
This is required because we're only working with `latest` image and if they already exist, Docker won't pull a new one.